### PR TITLE
Don't throw exception on status code 200, 201 and 204

### DIFF
--- a/src/Provider/Teamleader.php
+++ b/src/Provider/Teamleader.php
@@ -66,7 +66,7 @@ class Teamleader extends AbstractProvider
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
-        if ($response->getStatusCode() !== 200) {
+        if (!in_array($response->getStatusCode(), [200, 201, 204], true)) {
             throw TeamleaderIdentityProviderException::fromResponse($response);
         }
     }


### PR DESCRIPTION
I don't know how to work around this exception except for changing the source file.

Teamleader may also return 201 and 204. It doesn't mean it's a bad response.
https://developer.teamleader.eu/#/introduction/general-principles/status-codes