### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teamleader Provider for OAuth 2.0 Client
 
-This package provides [Teamleader](https://developer.teamleader.eu/) OAuth 2.0
+This package provides [Teamleader](https://developer.focus.teamleader.eu/) OAuth 2.0
 support for the PHP League's
 [OAuth 2.0 Client](https://github.com/thephpleague/oauth2-client).
 

--- a/src/Provider/Teamleader.php
+++ b/src/Provider/Teamleader.php
@@ -14,8 +14,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Teamleader extends AbstractProvider
 {
-    const OAUTH_BASE_URL = 'https://app.teamleader.eu/oauth2/';
-    const API_BASE_URL = 'https://api.teamleader.eu/';
+    const OAUTH_BASE_URL = 'https://focus.teamleader.eu/oauth2/';
+    const API_BASE_URL = 'https://api.focus.teamleader.eu/';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.